### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/Infrastructure.Core.Web/Middleware/FullRequestLoggingMiddleware.cs
+++ b/Infrastructure.Core.Web/Middleware/FullRequestLoggingMiddleware.cs
@@ -90,8 +90,8 @@ public class FullRequestLoggingMiddleware
         var logMessage = new StringBuilder();
 
         logMessage.AppendLine("FULL REQUEST/RESPONSE DUMP");
-        logMessage.AppendLine($"Method: {request.Method}");
-        logMessage.AppendLine($"Path: {request.Path}");
+        logMessage.AppendLine($"Method: {SanitizeValue(request.Method)}");
+        logMessage.AppendLine($"Path: {SanitizeValue(request.Path)}");
         logMessage.AppendLine($"StatusCode: {context.Response.StatusCode}");
         logMessage.AppendLine($"ExecutionTimeMs: {elapsedMs:0.00} ms");
         logMessage.AppendLine();

--- a/Infrastructure.Core/Utility/Sanitizer.cs
+++ b/Infrastructure.Core/Utility/Sanitizer.cs
@@ -1,0 +1,208 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SoftwaredeveloperDotAt.Infrastructure.Core.Utility;
+
+public static class StringSanitizer
+{
+    private const string TruncationSuffix = "...(truncated)";
+
+    private static readonly Regex HtmlTagRegex =
+        new("<.*?>", RegexOptions.Compiled);
+
+    private static readonly Regex MultipleWhitespaceRegex =
+        new(@"\s{2,}", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Sanitizes a string for safe logging: removes control/format/private-use characters
+    /// and limits the maximum length.
+    /// Sample: input "Hello\r\nWorld\u001b", output "Hello World".
+    /// </summary>
+    public static string Sanitize(string input, int maxLength = 1024)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        if (input.Length > maxLength)
+        {
+            int cutLength = Math.Max(0, maxLength - TruncationSuffix.Length);
+            input = input.Substring(0, cutLength) + TruncationSuffix;
+        }
+
+        var sb = new StringBuilder(input.Length);
+
+        foreach (var ch in input)
+        {
+            if (ch == '\r' || ch == '\n')
+            {
+                sb.Append(' ');
+                continue;
+            }
+
+            if (char.IsControl(ch))
+                continue;
+
+            var cat = CharUnicodeInfo.GetUnicodeCategory(ch);
+
+            switch (cat)
+            {
+                case UnicodeCategory.Format:
+                case UnicodeCategory.Surrogate:
+                case UnicodeCategory.PrivateUse:
+                case UnicodeCategory.OtherNotAssigned:
+                    continue;
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Normalizes whitespace: trims and collapses multiple whitespace characters into a single space.
+    /// Sample: input "  Hello\t  World  ", output "Hello World".
+    /// </summary>
+    public static string NormalizeWhitespace(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+
+        var trimmed = input.Trim();
+        return MultipleWhitespaceRegex.Replace(trimmed, " ");
+    }
+
+    /// <summary>
+    /// Removes diacritics (accents) from characters.
+    /// Sample: input "ÄÖÜ äöü éèç", output "AOU aou eec".
+    /// </summary>
+    public static string RemoveDiacritics(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        var normalized = input.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder();
+
+        foreach (var ch in normalized)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+            if (category != UnicodeCategory.NonSpacingMark)
+                sb.Append(ch);
+        }
+
+        return sb.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    /// <summary>
+    /// Strips HTML tags and decodes HTML entities, then normalizes whitespace.
+    /// Sample: input "&lt;p&gt;Hello &lt;strong&gt;World&lt;/strong&gt;&lt;/p&gt;", output "Hello World".
+    /// </summary>
+    public static string StripHtml(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        var decoded = WebUtility.HtmlDecode(input);
+        var noTags = HtmlTagRegex.Replace(decoded, string.Empty);
+
+        return NormalizeWhitespace(noTags);
+    }
+
+    /// <summary>
+    /// HTML-encodes a string for safe HTML output.
+    /// Sample: input "&lt;script&gt;alert('x')&lt;/script&gt;", output "&amp;lt;script&amp;gt;alert(&amp;#39;x&amp;#39;)&amp;lt;/script&amp;gt;".
+    /// </summary>
+    public static string HtmlEncode(string? input)
+    {
+        if (input == null)
+            return string.Empty;
+
+        return WebUtility.HtmlEncode(input);
+    }
+
+    /// <summary>
+    /// Allows only characters that match the given whitelist pattern.
+    /// Sample: input "User_123@example.com", pattern "a-zA-Z0-9_" => "User_123".
+    /// </summary>
+    public static string AllowOnly(string? input, string whitelistPattern)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        if (string.IsNullOrWhiteSpace(whitelistPattern))
+            throw new ArgumentException("Whitelist pattern must not be empty.");
+
+        var regex = new Regex($"[^{whitelistPattern}]+",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        return regex.Replace(input, string.Empty);
+    }
+
+    /// <summary>
+    /// Creates a filesystem-safe file name from an arbitrary string.
+    /// Sample: input "Mein *Dokument* 2024?.pdf", output ähnlich zu "Mein_Dokument_2024_.pdf".
+    /// </summary>
+    public static string ToSafeFileName(string? input, int maxLength = 255)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+
+        var cleaned = RemoveDiacritics(input);
+        cleaned = NormalizeWhitespace(cleaned);
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(cleaned.Length);
+
+        foreach (var ch in cleaned)
+        {
+            if (invalidChars.Contains(ch))
+                sb.Append('_');
+            else
+                sb.Append(ch);
+        }
+
+        var result = Regex.Replace(sb.ToString(), @"\s+", "_");
+        result = Regex.Replace(result, @"[^\w\-.()_]", "_");
+
+        if (result.Length > maxLength)
+            result = result.Substring(0, maxLength);
+
+        return result.Trim('_', ' ');
+    }
+
+    /// <summary>
+    /// Generates a URL-friendly slug from a string.
+    /// Sample: input "Änderungen im März 2024", output "anderungen-im-marz-2024".
+    /// </summary>
+    public static string ToUrlSlug(string? input, int maxLength = 200)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+
+        var slug = RemoveDiacritics(input)
+            .ToLowerInvariant();
+
+        slug = Regex.Replace(slug, @"[^a-z0-9]+", "-");
+        slug = Regex.Replace(slug, "-{2,}", "-").Trim('-');
+
+        if (slug.Length > maxLength)
+            slug = slug.Substring(0, maxLength).Trim('-');
+
+        return slug;
+    }
+
+    /// <summary>
+    /// Escapes single quotes for use in legacy SQL string concatenation.
+    /// Sample: input "O'Hara", output "O''Hara".
+    /// </summary>
+    public static string SanitizeForSql(string? input)
+    {
+        if (input == null)
+            return string.Empty;
+
+        return input.Replace("'", "''");
+    }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/Kloew001/Softwaredeveloper.at/security/code-scanning/3](https://github.com/Kloew001/Softwaredeveloper.at/security/code-scanning/3)

In general, to fix log-forging issues, all user-controlled values included in log messages should be sanitized before logging: remove or normalize newline and control characters for plain-text logs, or HTML-encode if logs are rendered as HTML. It is also useful to make user input clearly delimited so injected content cannot imitate surrounding structure.

For this specific middleware, the safest change without altering functionality is to ensure that all user-provided strings in the log—including `request.Method` and `request.Path`—are passed through the same sanitation function already used for headers, query, and route values. Since there is already a `SanitizeValue` helper in this file (used for headers, query, route values), we should reuse it for `Method` and `Path`. This likely trims or strips problematic characters (including newlines); if it doesn’t, that helper can be improved elsewhere, but we are constrained to this snippet, so we will just ensure it is applied consistently.

Concretely, adjust the log-building lines around 93–95 so they use `SanitizeValue`:

- Change `logMessage.AppendLine($"Method: {request.Method}");` to use `SanitizeValue(request.Method)`.
- Change `logMessage.AppendLine($"Path: {request.Path}");` to use `SanitizeValue(request.Path);`.

We do not need new imports or new methods; we are only reusing the existing `SanitizeValue` helper that already exists in this file and is invoked for header/query/route logging. This keeps behavior consistent (whatever the project authors already defined as “sanitized”) and addresses all CodeQL variants pointing to unsanitized user input reaching the logger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
